### PR TITLE
fix: rename to speed_scale_factor

### DIFF
--- a/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
@@ -134,7 +134,7 @@ private:
   double vgr_coef_c_;                // variable gear ratio coeffs
   double accel_pedal_offset_;        // offset of accel pedal value
   double brake_pedal_offset_;        // offset of brake pedal value
-  double tire_radius_scale_factor_;  // scale factor of tire radius
+  double speed_scale_factor_;        // scale factor of speed
 
   double emergency_brake_;              // brake command when emergency [m/s^2]
   double max_throttle_;                 // max throttle [0~1]

--- a/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
@@ -125,16 +125,16 @@ private:
   bool is_pacmod_enabled_ = false;
   bool is_clear_override_needed_ = false;
   bool prev_override_ = false;
-  double loop_rate_;                 // [Hz]
-  double tire_radius_;               // [m]
-  double wheel_base_;                // [m]
-  double steering_offset_;           // [rad] def: measured = truth + offset
-  double vgr_coef_a_;                // variable gear ratio coeffs
-  double vgr_coef_b_;                // variable gear ratio coeffs
-  double vgr_coef_c_;                // variable gear ratio coeffs
-  double accel_pedal_offset_;        // offset of accel pedal value
-  double brake_pedal_offset_;        // offset of brake pedal value
-  double speed_scale_factor_;        // scale factor of speed
+  double loop_rate_;           // [Hz]
+  double tire_radius_;         // [m]
+  double wheel_base_;          // [m]
+  double steering_offset_;     // [rad] def: measured = truth + offset
+  double vgr_coef_a_;          // variable gear ratio coeffs
+  double vgr_coef_b_;          // variable gear ratio coeffs
+  double vgr_coef_c_;          // variable gear ratio coeffs
+  double accel_pedal_offset_;  // offset of accel pedal value
+  double brake_pedal_offset_;  // offset of brake pedal value
+  double speed_scale_factor_;  // scale factor of speed
 
   double emergency_brake_;              // brake command when emergency [m/s^2]
   double max_throttle_;                 // max throttle [0~1]

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
@@ -44,7 +44,7 @@ PacmodInterface::PacmodInterface()
   vgr_coef_c_ = declare_parameter("vgr_coef_c", 0.042);
   accel_pedal_offset_ = declare_parameter("accel_pedal_offset", 0.0);
   brake_pedal_offset_ = declare_parameter("brake_pedal_offset", 0.0);
-  tire_radius_scale_factor_ = declare_parameter("tire_radius_scale_factor", 1.0);
+  speed_scale_factor_ = declare_parameter("speed_scale_factor", 1.0);
 
   /* parameters for limitter */
   max_throttle_ = declare_parameter("max_throttle", 0.2);
@@ -522,7 +522,7 @@ double PacmodInterface::calculateVehicleVelocity(
   const double sign = (shift_rpt.output == pacmod3_msgs::msg::SystemRptInt::SHIFT_REVERSE) ? -1 : 1;
   const double vel =
     (wheel_speed_rpt.rear_left_wheel_speed + wheel_speed_rpt.rear_right_wheel_speed) * 0.5 *
-    tire_radius_ * tire_radius_scale_factor_;
+    tire_radius_ * speed_scale_factor_;
   return sign * vel;
 }
 


### PR DESCRIPTION
Rename tire_radius_scale_factor to speed_scale_factor

--- Background ---
This scale factor is used for velocity correction.
This is not always used to correct the tire radius, and is also effective against changes in slip rate due to tire wear.
To match the definition of coefficient for velocity, rename tire_radius_scale_factor to speed_scale_factor

Related PR(Tier IV internal) : https://github.com/tier4/autoware_individual_params.jpntaxi/pull/39