### PR TITLE
chore(pacmod_interface): invert steering offset definition

### DIFF
--- a/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
@@ -248,7 +248,7 @@ void PacmodInterface::callbackPacmodRpt(
     steer_wheel_rpt_ptr_->output;  // current vehicle steering wheel angle [rad]
   const double adaptive_gear_ratio =
     calculateVariableGearRatio(current_velocity, current_steer_wheel);
-  const double current_steer = current_steer_wheel / adaptive_gear_ratio - steering_offset_;
+  const double current_steer = current_steer_wheel / adaptive_gear_ratio + steering_offset_;
 
   std_msgs::msg::Header header;
   header.frame_id = base_frame_id_;


### PR DESCRIPTION
Signed-off-by: Shumpei Wakabayashi <shumpei.wakabayashi@tier4.jp>

Follow "steering_offset" definition as 
```
measured = truth + offset
```


Note that this PR should sync https://github.com/tier4/autoware_individual_params.jpntaxi/pull/43