### PR TITLE
feat(pacmod_interface): support control_mode_request for auto/manual mode change

### DIFF
--- a/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
@@ -41,10 +41,10 @@
 #include <tier4_external_api_msgs/srv/set_door.hpp>
 #include <tier4_vehicle_msgs/msg/actuation_command_stamped.hpp>
 #include <tier4_vehicle_msgs/msg/actuation_status_stamped.hpp>
+#include <tier4_vehicle_msgs/msg/control_mode.hpp>
 #include <tier4_vehicle_msgs/msg/steering_wheel_status_stamped.hpp>
 #include <tier4_vehicle_msgs/msg/vehicle_emergency_stamped.hpp>
 #include <tier4_vehicle_msgs/srv/control_mode_request.hpp>
-#include <tier4_vehicle_msgs/msg/control_mode.hpp>
 
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>

--- a/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
@@ -82,7 +82,6 @@ private:
     turn_indicators_cmd_sub_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
     hazard_lights_cmd_sub_;
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::Engage>::SharedPtr engage_cmd_sub_;
   rclcpp::Subscription<ActuationCommandStamped>::SharedPtr actuation_cmd_sub_;
   rclcpp::Subscription<tier4_vehicle_msgs::msg::VehicleEmergencyStamped>::SharedPtr emergency_sub_;
 

--- a/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
@@ -43,6 +43,8 @@
 #include <tier4_vehicle_msgs/msg/actuation_status_stamped.hpp>
 #include <tier4_vehicle_msgs/msg/steering_wheel_status_stamped.hpp>
 #include <tier4_vehicle_msgs/msg/vehicle_emergency_stamped.hpp>
+#include <tier4_vehicle_msgs/srv/control_mode_request.hpp>
+#include <tier4_vehicle_msgs/msg/control_mode.hpp>
 
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
@@ -163,6 +165,7 @@ private:
 
   // Service
   tier4_api_utils::Service<tier4_external_api_msgs::srv::SetDoor>::SharedPtr srv_;
+  rclcpp::Service<tier4_vehicle_msgs::srv::ControlModeRequest>::SharedPtr control_mode_server_;
 
   /* input values */
   ActuationCommandStamped::ConstSharedPtr actuation_cmd_ptr_;
@@ -239,6 +242,9 @@ private:
     const tier4_external_api_msgs::srv::SetDoor::Response::SharedPtr response);
   tier4_api_msgs::msg::DoorStatus toAutowareDoorStatusMsg(
     const pacmod3_msgs::msg::SystemRptInt & msg_ptr);
+  void onControlModeRequest(
+    const tier4_vehicle_msgs::srv::ControlModeRequest::Request::SharedPtr request,
+    const tier4_vehicle_msgs::srv::ControlModeRequest::Response::SharedPtr response);
 };
 
 #endif  // PACMOD_INTERFACE__PACMOD_INTERFACE_HPP_

--- a/pacmod_interface/launch/pacmod_interface.launch.xml
+++ b/pacmod_interface/launch/pacmod_interface.launch.xml
@@ -10,6 +10,7 @@
   <node pkg="pacmod_interface" exec="pacmod_interface" name="pacmod_interface" output="screen">
     <param from="$(var pacmod_param_path)"/>
     <param from="$(var vehicle_info_param_file)"/>
+    <remap from="input/control_mode_request" to="/control/control_mode_request"/>
   </node>
 
   <!-- pacmod diagnostics publisher -->

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
@@ -89,11 +89,6 @@ PacmodInterface::PacmodInterface()
   control_mode_server_ = create_service<tier4_vehicle_msgs::srv::ControlModeRequest>(
     "input/control_mode_request", std::bind(&PacmodInterface::onControlModeRequest, this, _1, _2));
 
-  // TODO(Horibe): remove engage interface. keep now for backward compatibility.
-  engage_cmd_sub_ = create_subscription<autoware_auto_vehicle_msgs::msg::Engage>(
-    "/vehicle/engage", rclcpp::QoS{1}, std::bind(&PacmodInterface::callbackEngage, this, _1));
-
-
   // From pacmod
 
   steer_wheel_rpt_sub_ =
@@ -212,13 +207,6 @@ void PacmodInterface::callbackHazardLightsCommand(
   const autoware_auto_vehicle_msgs::msg::HazardLightsCommand::ConstSharedPtr msg)
 {
   hazard_lights_cmd_ptr_ = msg;
-}
-
-void PacmodInterface::callbackEngage(
-  const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
-{
-  engage_cmd_ = msg->engage;
-  is_clear_override_needed_ = true;
 }
 
 void PacmodInterface::onControlModeRequest(

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
@@ -213,14 +213,14 @@ void PacmodInterface::onControlModeRequest(
   const tier4_vehicle_msgs::srv::ControlModeRequest::Request::SharedPtr request,
   const tier4_vehicle_msgs::srv::ControlModeRequest::Response::SharedPtr response)
 {
-  if (request->mode.data == tier4_vehicle_msgs::msg::ControlMode::AUTO){
+  if (request->mode.data == tier4_vehicle_msgs::msg::ControlMode::AUTO) {
     engage_cmd_ = true;
     is_clear_override_needed_ = true;
     response->success = true;
     return;
   }
 
-  if (request->mode.data == tier4_vehicle_msgs::msg::ControlMode::MANUAL){
+  if (request->mode.data == tier4_vehicle_msgs::msg::ControlMode::MANUAL) {
     engage_cmd_ = false;
     is_clear_override_needed_ = true;
     response->success = true;

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
@@ -64,6 +64,7 @@ PacmodInterface::PacmodInterface()
 
   /* subscribers */
   using std::placeholders::_1;
+  using std::placeholders::_2;
 
   // From autoware
   control_cmd_sub_ = create_subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>(
@@ -78,14 +79,20 @@ PacmodInterface::PacmodInterface()
     create_subscription<autoware_auto_vehicle_msgs::msg::HazardLightsCommand>(
       "/control/command/hazard_lights_cmd", rclcpp::QoS{1},
       std::bind(&PacmodInterface::callbackHazardLightsCommand, this, _1));
-  engage_cmd_sub_ = create_subscription<autoware_auto_vehicle_msgs::msg::Engage>(
-    "/vehicle/engage", rclcpp::QoS{1}, std::bind(&PacmodInterface::callbackEngage, this, _1));
+
   actuation_cmd_sub_ = create_subscription<ActuationCommandStamped>(
     "/control/command/actuation_cmd", 1,
     std::bind(&PacmodInterface::callbackActuationCmd, this, _1));
   emergency_sub_ = create_subscription<tier4_vehicle_msgs::msg::VehicleEmergencyStamped>(
     "/control/command/emergency_cmd", 1,
     std::bind(&PacmodInterface::callbackEmergencyCmd, this, _1));
+  control_mode_server_ = create_service<tier4_vehicle_msgs::srv::ControlModeRequest>(
+    "input/control_mode_request", std::bind(&PacmodInterface::onControlModeRequest, this, _1, _2));
+
+  // TODO(Horibe): remove engage interface. keep now for backward compatibility.
+  engage_cmd_sub_ = create_subscription<autoware_auto_vehicle_msgs::msg::Engage>(
+    "/vehicle/engage", rclcpp::QoS{1}, std::bind(&PacmodInterface::callbackEngage, this, _1));
+
 
   // From pacmod
 
@@ -212,6 +219,29 @@ void PacmodInterface::callbackEngage(
 {
   engage_cmd_ = msg->engage;
   is_clear_override_needed_ = true;
+}
+
+void PacmodInterface::onControlModeRequest(
+  const tier4_vehicle_msgs::srv::ControlModeRequest::Request::SharedPtr request,
+  const tier4_vehicle_msgs::srv::ControlModeRequest::Response::SharedPtr response)
+{
+  if (request->mode.data == tier4_vehicle_msgs::msg::ControlMode::AUTO){
+    engage_cmd_ = true;
+    is_clear_override_needed_ = true;
+    response->success = true;
+    return;
+  }
+
+  if (request->mode.data == tier4_vehicle_msgs::msg::ControlMode::MANUAL){
+    engage_cmd_ = false;
+    is_clear_override_needed_ = true;
+    response->success = true;
+    return;
+  }
+
+  RCLCPP_ERROR(get_logger(), "unsupported control_mode!!");
+  response->success = false;
+  return;
 }
 
 void PacmodInterface::callbackPacmodRpt(


### PR DESCRIPTION
add control_mode_request interface for auto/manual mode change.
The behavior when receives the request is similar to the case of /vehicle/engage.

This change depends on https://github.com/tier4/tier4_ad_api_adaptor/pull/51