### PR TITLE
feat(pacmod_interface): update engage_sequence

### DIFF
--- a/pacmod_interface/config/pacmod.param.yaml
+++ b/pacmod_interface/config/pacmod.param.yaml
@@ -17,3 +17,4 @@
     vgr_coef_c: 0.042
     accel_pedal_offset: 0.0
     brake_pedal_offset: 0.0
+    need_separate_engage_sequence: false

--- a/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
@@ -153,7 +153,9 @@ private:
   double steering_wheel_rate_stopped_;  // [rad/s]
   double low_vel_thresh_;               // [m/s]
 
-  bool enable_steering_rate_control_;  // use steering angle speed for command [rad/s]
+  bool enable_steering_rate_control_;   // use steering angle speed for command [rad/s]
+  bool need_separate_engage_sequence_;  // when you use a newer version of firmware than 3.3, it
+                                        // must be true
 
   double hazard_thresh_time_;
   int hazard_recover_count_ = 0;

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
@@ -456,7 +456,12 @@ void PacmodInterface::publishCommands()
     pacmod3_msgs::msg::SystemCmdFloat accel_cmd;
     accel_cmd.header.frame_id = base_frame_id_;
     accel_cmd.header.stamp = current_time;
-    accel_cmd.enable = engage_cmd_;
+    /*
+    For changing to auto mode, it needs to be following two messages
+    1. Send a msg with clear override bit high and enable bit low.
+    2. Send a msg after that, with clear override bit low, and enable bit high.
+    */
+    accel_cmd.enable = clear_override ? false : engage_cmd_;
     accel_cmd.ignore_overrides = false;
     accel_cmd.clear_override = clear_override;
     accel_cmd.command = std::max(0.0, std::min(desired_throttle, max_throttle_));
@@ -468,7 +473,7 @@ void PacmodInterface::publishCommands()
     pacmod3_msgs::msg::SystemCmdFloat brake_cmd;
     brake_cmd.header.frame_id = base_frame_id_;
     brake_cmd.header.stamp = current_time;
-    brake_cmd.enable = engage_cmd_;
+    brake_cmd.enable = clear_override ? false : engage_cmd_;
     brake_cmd.ignore_overrides = false;
     brake_cmd.clear_override = clear_override;
     brake_cmd.command = std::max(0.0, std::min(desired_brake, max_brake_));
@@ -480,7 +485,7 @@ void PacmodInterface::publishCommands()
     pacmod3_msgs::msg::SteeringCmd steer_cmd;
     steer_cmd.header.frame_id = base_frame_id_;
     steer_cmd.header.stamp = current_time;
-    steer_cmd.enable = engage_cmd_;
+    steer_cmd.enable = clear_override ? false : engage_cmd_;
     steer_cmd.ignore_overrides = false;
     steer_cmd.clear_override = clear_override;
     steer_cmd.rotation_rate = calcSteerWheelRateCmd(adaptive_gear_ratio);
@@ -496,7 +501,7 @@ void PacmodInterface::publishCommands()
     pacmod3_msgs::msg::SteeringCmd raw_steer_cmd;
     raw_steer_cmd.header.frame_id = base_frame_id_;
     raw_steer_cmd.header.stamp = current_time;
-    raw_steer_cmd.enable = engage_cmd_;
+    raw_steer_cmd.enable = clear_override ? false : engage_cmd_;
     raw_steer_cmd.ignore_overrides = false;
     raw_steer_cmd.clear_override = clear_override;
     raw_steer_cmd.command = desired_steer_wheel;
@@ -510,7 +515,7 @@ void PacmodInterface::publishCommands()
     pacmod3_msgs::msg::SystemCmdInt shift_cmd;
     shift_cmd.header.frame_id = base_frame_id_;
     shift_cmd.header.stamp = current_time;
-    shift_cmd.enable = engage_cmd_;
+    shift_cmd.enable = clear_override ? false : engage_cmd_;
     shift_cmd.ignore_overrides = false;
     shift_cmd.clear_override = clear_override;
     shift_cmd.command = desired_shift;
@@ -518,11 +523,11 @@ void PacmodInterface::publishCommands()
   }
 
   if (turn_indicators_cmd_ptr_ && hazard_lights_cmd_ptr_) {
-    /* publish shift cmd */
+    /* publish turn cmd */
     pacmod3_msgs::msg::SystemCmdInt turn_cmd;
     turn_cmd.header.frame_id = base_frame_id_;
     turn_cmd.header.stamp = current_time;
-    turn_cmd.enable = engage_cmd_;
+    turn_cmd.enable = clear_override ? false : engage_cmd_;
     turn_cmd.ignore_overrides = false;
     turn_cmd.clear_override = clear_override;
     turn_cmd.command =

--- a/pacmod_interface/src/pacmod_steer_test/pacmod_steer_test.cpp
+++ b/pacmod_interface/src/pacmod_steer_test/pacmod_steer_test.cpp
@@ -234,7 +234,7 @@ void PacmodSteerTest::publishCommands()
     pacmod3_msgs::msg::SystemCmdFloat accel_cmd;
     accel_cmd.header.frame_id = base_frame_id_;
     accel_cmd.header.stamp = current_time;
-    accel_cmd.enable = engage_cmd_;
+    accel_cmd.enable = clear_override ? false : engage_cmd_;
     accel_cmd.ignore_overrides = false;
     accel_cmd.clear_override = clear_override;
     accel_cmd.command = getAccel();
@@ -246,7 +246,7 @@ void PacmodSteerTest::publishCommands()
     pacmod3_msgs::msg::SystemCmdFloat brake_cmd;
     brake_cmd.header.frame_id = base_frame_id_;
     brake_cmd.header.stamp = current_time;
-    brake_cmd.enable = engage_cmd_;
+    brake_cmd.enable = clear_override ? false : engage_cmd_;
     brake_cmd.ignore_overrides = false;
     brake_cmd.clear_override = clear_override;
     brake_cmd.command = getBrake();
@@ -258,7 +258,7 @@ void PacmodSteerTest::publishCommands()
     pacmod3_msgs::msg::SteeringCmd steer_cmd;
     steer_cmd.header.frame_id = base_frame_id_;
     steer_cmd.header.stamp = current_time;
-    steer_cmd.enable = engage_cmd_;
+    steer_cmd.enable = clear_override ? false : engage_cmd_;
     steer_cmd.ignore_overrides = false;
     steer_cmd.clear_override = clear_override;
     steer_cmd.command = testSteerCommand();  // desired_steer_wheel;
@@ -271,18 +271,18 @@ void PacmodSteerTest::publishCommands()
     pacmod3_msgs::msg::SystemCmdInt shift_cmd;
     shift_cmd.header.frame_id = base_frame_id_;
     shift_cmd.header.stamp = current_time;
-    shift_cmd.enable = engage_cmd_;
+    shift_cmd.enable = clear_override ? false : engage_cmd_;
     shift_cmd.ignore_overrides = false;
     shift_cmd.clear_override = clear_override;
     shift_cmd.command = pacmod3_msgs::msg::SystemCmdInt::SHIFT_FORWARD;  // always drive shift
     shift_cmd_pub_->publish(shift_cmd);
   }
 
-  /* publish shift cmd */
+  /* publish turn cmd */
   pacmod3_msgs::msg::SystemCmdInt turn_cmd;
   turn_cmd.header.frame_id = base_frame_id_;
   turn_cmd.header.stamp = current_time;
-  turn_cmd.enable = engage_cmd_;
+  turn_cmd.enable = clear_override ? false : engage_cmd_;
   turn_cmd.ignore_overrides = false;
   turn_cmd.clear_override = clear_override;
   turn_cmd.command = pacmod3_msgs::msg::SystemCmdInt::TURN_HAZARDS;  // for safety


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

Updated the engage sequence to match pacmod's FW

>  the newest firmware is stricter at implementing clear override, and disable before enable sequence. It functions as documented. From the plot you shared, it looks like you just need to break up into two messages enabling after an override.
-- Send a msg with clear override bit high and enable bit low.
-- Send a msg after that, with clear override bit low, and enable bit high.
It needs to be two distinct messages as in #1 and #2. From your plot, it looks like it is done in one message. If you do that, you'll see what happened. Enable fails, but override active is set low, then the second time you try to enable, it works.
For the second plot, to diagnose properly what happened and provide guidance, can you share the raw CAN log/data for this event ("only accel/brake switched to auto")?
