### PR TITLE
fix(pacmod_diag_publisher): fix can topic name

### DIFF
--- a/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
@@ -37,7 +37,8 @@ PacmodDiagPublisher::PacmodDiagPublisher()
 
   /* register subscribers */
   can_sub_ = create_subscription<can_msgs::msg::Frame>(
-    "/pacmod/can_tx", 1, std::bind(&PacmodDiagPublisher::callbackCan, this, std::placeholders::_1));
+    "/pacmod/from_can_bus", 1,
+    std::bind(&PacmodDiagPublisher::callbackCan, this, std::placeholders::_1));
 
   steer_wheel_rpt_sub_ =
     std::make_unique<message_filters::Subscriber<pacmod3_msgs::msg::SystemRptFloat>>(


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

I fixed can topic name in pacmod_diag_publisher.
( /pacmod/can_tx -> /pacmod/from_can_bus )