### PR TITLE
feat: add diagnostics of pacmod accel and brake fault detection

### DIFF
--- a/pacmod_interface/config/pacmod_diag_publisher.param.yaml
+++ b/pacmod_interface/config/pacmod_diag_publisher.param.yaml
@@ -1,0 +1,10 @@
+/**:
+  ros__parameters:
+    can_timeout_sec: 10.0
+    pacmod_msg_timeout_sec: 10.0
+    update_rate: 10.0
+    accel_store_time: 1.0
+    accel_diff_thresh: 1.0
+    min_decel: -3.0
+    max_accel: 3.0
+    accel_brake_fault_check_min_velocity: 1.39

--- a/pacmod_interface/include/pacmod_interface/pacmod_diag_publisher.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_diag_publisher.hpp
@@ -39,6 +39,8 @@
 #include <cstdlib>
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 using autoware_auto_control_msgs::msg::AckermannControlCommand;
 using geometry_msgs::msg::AccelWithCovarianceStamped;

--- a/pacmod_interface/include/pacmod_interface/pacmod_diag_publisher.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_diag_publisher.hpp
@@ -18,7 +18,9 @@
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
 #include <can_msgs/msg/frame.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <pacmod3_msgs/msg/global_rpt.hpp>
 #include <pacmod3_msgs/msg/steering_cmd.hpp>
 #include <pacmod3_msgs/msg/system_cmd_float.hpp>
@@ -36,6 +38,9 @@
 #include <cstdlib>
 #include <memory>
 #include <string>
+
+using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using geometry_msgs::msg::AccelWithCovarianceStamped;
 
 class PacmodDiagPublisher : public rclcpp::Node
 {
@@ -65,6 +70,10 @@ private:
   // From CAN
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr can_sub_;
 
+  // Accleration-related Topics
+  rclcpp::Subscription<AccelWithCovarianceStamped>::SharedPtr current_acc_sub_;
+  rclcpp::Subscription<AckermannControlCommand>::SharedPtr control_cmd_sub_;
+
   /* ros parameters */
   double can_timeout_sec_;
   double pacmod3_msgs_timeout_sec_;
@@ -84,6 +93,14 @@ private:
   // Diagnostic Updater
   std::shared_ptr<diagnostic_updater::Updater> updater_ptr_;
 
+  // Accleration
+  std::vector<std::pair<builtin_interfaces::msg::Time, double>> acc_que_;
+  std::vector<std::pair<builtin_interfaces::msg::Time, double>> acc_cmd_que_;
+  double accel_store_time_;
+  double accel_diff_thresh_;
+  double min_decel_;
+  double max_accel_;
+
   /* callbacks */
   void callbackPacmodRpt(
     const pacmod3_msgs::msg::SystemRptFloat::ConstSharedPtr steer_wheel_rpt,
@@ -96,9 +113,24 @@ private:
 
   void callbackCan(const can_msgs::msg::Frame::ConstSharedPtr can);
 
+  void callbackAccel(const AccelWithCovarianceStamped::ConstSharedPtr accel);
+  void callbackControlCmd(const AckermannControlCommand::ConstSharedPtr control_cmd);
+
   /* functions */
   void checkPacmodMsgs(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void checkPacmodAccelBrake(diagnostic_updater::DiagnosticStatusWrapper & stat);
   std::string addMsg(const std::string & original_msg, const std::string & additional_msg);
+
+  void addValueToQue(
+    std::vector<std::pair<builtin_interfaces::msg::Time, double>> & que, const double value,
+    const builtin_interfaces::msg::Time timestamp, const double store_time);
+  bool checkEnoughDataStored(
+    const std::vector<std::pair<builtin_interfaces::msg::Time, double>> que,
+    const double store_time);
+  double getMinValue(std::vector<std::pair<builtin_interfaces::msg::Time, double>> que);
+  double getMaxValue(std::vector<std::pair<builtin_interfaces::msg::Time, double>> que);
+  bool checkAccelFault();
+  bool checkBrakeFault();
 
   bool isTimeoutCanMsgs();
   bool isTimeoutPacmodMsgs();

--- a/pacmod_interface/include/pacmod_interface/pacmod_diag_publisher.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_diag_publisher.hpp
@@ -21,6 +21,7 @@
 #include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
 #include <can_msgs/msg/frame.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 #include <pacmod3_msgs/msg/global_rpt.hpp>
 #include <pacmod3_msgs/msg/steering_cmd.hpp>
 #include <pacmod3_msgs/msg/system_cmd_float.hpp>
@@ -41,6 +42,7 @@
 
 using autoware_auto_control_msgs::msg::AckermannControlCommand;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
+using nav_msgs::msg::Odometry;
 
 class PacmodDiagPublisher : public rclcpp::Node
 {
@@ -73,6 +75,7 @@ private:
   // Accleration-related Topics
   rclcpp::Subscription<AccelWithCovarianceStamped>::SharedPtr current_acc_sub_;
   rclcpp::Subscription<AckermannControlCommand>::SharedPtr control_cmd_sub_;
+  rclcpp::Subscription<Odometry>::SharedPtr odom_sub_;
 
   /* ros parameters */
   double can_timeout_sec_;
@@ -89,17 +92,19 @@ private:
   pacmod3_msgs::msg::SystemRptInt::ConstSharedPtr shift_rpt_ptr_;
   pacmod3_msgs::msg::GlobalRpt::ConstSharedPtr global_rpt_ptr_;
   pacmod3_msgs::msg::SystemRptInt::ConstSharedPtr turn_rpt_ptr_;
+  Odometry::ConstSharedPtr odom_ptr_;
 
   // Diagnostic Updater
   std::shared_ptr<diagnostic_updater::Updater> updater_ptr_;
 
-  // Accleration
+  // Acceleration
   std::vector<std::pair<builtin_interfaces::msg::Time, double>> acc_que_;
   std::vector<std::pair<builtin_interfaces::msg::Time, double>> acc_cmd_que_;
   double accel_store_time_;
   double accel_diff_thresh_;
   double min_decel_;
   double max_accel_;
+  double accel_brake_fault_check_min_velocity_;
 
   /* callbacks */
   void callbackPacmodRpt(
@@ -114,6 +119,7 @@ private:
   void callbackCan(const can_msgs::msg::Frame::ConstSharedPtr can);
 
   void callbackAccel(const AccelWithCovarianceStamped::ConstSharedPtr accel);
+  void callbackOdometry(const Odometry::SharedPtr odom);
   void callbackControlCmd(const AckermannControlCommand::ConstSharedPtr control_cmd);
 
   /* functions */

--- a/pacmod_interface/include/pacmod_interface/pacmod_diag_publisher.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_diag_publisher.hpp
@@ -72,7 +72,7 @@ private:
   // From CAN
   rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr can_sub_;
 
-  // Accleration-related Topics
+  // Acceleration-related Topics
   rclcpp::Subscription<AccelWithCovarianceStamped>::SharedPtr current_acc_sub_;
   rclcpp::Subscription<AckermannControlCommand>::SharedPtr control_cmd_sub_;
   rclcpp::Subscription<Odometry>::SharedPtr odom_sub_;

--- a/pacmod_interface/launch/pacmod_interface.launch.xml
+++ b/pacmod_interface/launch/pacmod_interface.launch.xml
@@ -2,6 +2,8 @@
 <launch>
   <arg name="pacmod_param_path" default="$(find-pkg-share pacmod_interface)/config/pacmod.param.yaml"/>
   <arg name="pacmod_extra_param_path" default="$(find-pkg-share pacmod_interface)/config/pacmod_extra.param.yaml"/>
+  <arg name="pacmod_diag_publisher_param_path" default="$(find-pkg-share pacmod_interface)/config/pacmod_diag_publisher.param.yaml"/>
+
 
   <!-- vehicle info -->
   <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml"/>
@@ -14,7 +16,9 @@
   </node>
 
   <!-- pacmod diagnostics publisher -->
-  <node pkg="pacmod_interface" exec="pacmod_diag_publisher" name="pacmod_diag_publisher" output="screen"/>
+  <node pkg="pacmod_interface" exec="pacmod_diag_publisher" name="pacmod_diag_publisher" output="screen">
+    <param from="$(var pacmod_diag_publisher_param_path)"/>
+  </node>
 
   <!-- pacmod additional parameter changer -->
   <node pkg="pacmod_interface" exec="pacmod_dynamic_parameter_changer" name="pacmod_dynamic_parameter_changer" output="screen">

--- a/pacmod_interface/launch/pacmod_interface.launch.xml
+++ b/pacmod_interface/launch/pacmod_interface.launch.xml
@@ -4,7 +4,6 @@
   <arg name="pacmod_extra_param_path" default="$(find-pkg-share pacmod_interface)/config/pacmod_extra.param.yaml"/>
   <arg name="pacmod_diag_publisher_param_path" default="$(find-pkg-share pacmod_interface)/config/pacmod_diag_publisher.param.yaml"/>
 
-
   <!-- vehicle info -->
   <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml"/>
 

--- a/pacmod_interface/package.xml
+++ b/pacmod_interface/package.xml
@@ -19,6 +19,8 @@
   <depend>diagnostic_updater</depend>
   <depend>message_filters</depend>
   <depend>pacmod3_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>tier4_api_msgs</depend>

--- a/pacmod_interface/package.xml
+++ b/pacmod_interface/package.xml
@@ -17,10 +17,10 @@
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>can_msgs</depend>
   <depend>diagnostic_updater</depend>
-  <depend>message_filters</depend>
-  <depend>pacmod3_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>message_filters</depend>
   <depend>nav_msgs</depend>
+  <depend>pacmod3_msgs</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>tier4_api_msgs</depend>

--- a/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
@@ -199,7 +199,7 @@ void PacmodDiagPublisher::checkPacmodAccelBrake(diagnostic_updater::DiagnosticSt
   }
 
   if (
-    !checkEnoughDataStored(acc_que_, accel_store_time_) or
+    !checkEnoughDataStored(acc_que_, accel_store_time_) ||
     !checkEnoughDataStored(acc_cmd_que_, accel_store_time_)) {
     // no enough data
     stat.summary(level, msg);

--- a/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
@@ -208,10 +208,10 @@ void PacmodDiagPublisher::checkPacmodAccelBrake(diagnostic_updater::DiagnosticSt
 
   if (checkBrakeFault()) {
     level = DiagStatus::ERROR;
-    msg = addMsg(msg, "Pacmod Brake Fault. Not accelerating enough.");
+    msg = addMsg(msg, "Pacmod Brake Fault. Not decelerating enough.");
   } else if (checkAccelFault()) {
     level = DiagStatus::ERROR;
-    msg = addMsg(msg, "Pacmod Accel Fault. Not decelerating enough.");
+    msg = addMsg(msg, "Pacmod Accel Fault. Not accelerating enough.");
   }
 
   stat.summary(level, msg);

--- a/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
@@ -41,7 +41,7 @@ PacmodDiagPublisher::PacmodDiagPublisher()
   updater_ptr_ = std::make_shared<diagnostic_updater::Updater>(this, 1.0 / update_rate);
   updater_ptr_->setHardwareID("pacmod_checker");
   updater_ptr_->add("pacmod_checker", this, &PacmodDiagPublisher::checkPacmodMsgs);
-  updater_ptr_->add("pacmod_brake", this, &PacmodDiagPublisher::checkPacmodAccelBrake);
+  updater_ptr_->add("pacmod_accel_brake_fault", this, &PacmodDiagPublisher::checkPacmodAccelBrake);
 
   /* register subscribers */
   can_sub_ = create_subscription<can_msgs::msg::Frame>(

--- a/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
@@ -307,7 +307,7 @@ bool PacmodDiagPublisher::checkBrakeFault()
 {
   const auto minimum_acc = getMinValue(acc_que_);
   const auto maximum_acc_cmd = std::max(getMaxValue(acc_cmd_que_), min_decel_);
-  if (maximum_acc_cmd < 0.0 && maximum_acc_cmd - minimum_acc < accel_diff_thresh_) {
+  if (maximum_acc_cmd < 0.0 && maximum_acc_cmd - minimum_acc < -accel_diff_thresh_) {
     // The vehicle deceleration is significantly lower than the deceleration command
     // Deceleration may be not working properly
     return true;


### PR DESCRIPTION
## Desription
Add diagnostics of pacmod accel/brake fault detection.
This is a function that publishes faults in the accelerator and brake modules as diagnostics when the acceleration/deceleration value deviates greatly from the command
![image](https://user-images.githubusercontent.com/59680180/227476025-a384b07a-6027-4a48-92d7-ae4a4ade6a00.png)


## Review Procedure
- run pacmod_diag_publisher
$ros2 run pacmod_interface pacmod_diag_publisher --ros-args -p use_sim_time:=true
- check diagnostics
$ros2 topic echo /diagnostics|grep pacmod_accel_brake_fault -B 1 -A 1
- confirm that pacmod_accel_brake_fault is published.
![image](https://user-images.githubusercontent.com/59680180/227474127-b8718a7a-1df6-44b0-be13-c6456de70c66.png)

By lowering the threshold of accel_diff_thresh, it is easy to confirm that error diags are output.
$ros2 run pacmod_interface pacmod_diag_publisher --ros-args -p use_sim_time:=true -p accel_diff_thresh:=0.1
![image](https://user-images.githubusercontent.com/59680180/227474855-183375e1-8445-40e2-bc2c-eb22be47e28d.png)

