### PR TITLE
fix: fix accel and brake fault messages

### DIFF
--- a/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
@@ -208,10 +208,10 @@ void PacmodDiagPublisher::checkPacmodAccelBrake(diagnostic_updater::DiagnosticSt
 
   if (checkBrakeFault()) {
     level = DiagStatus::ERROR;
-    msg = addMsg(msg, "Pacmod Brake Fault. Not decelerating enough.");
+    msg = "Pacmod Brake Fault. Not decelerating enough.";
   } else if (checkAccelFault()) {
     level = DiagStatus::ERROR;
-    msg = addMsg(msg, "Pacmod Accel Fault. Not accelerating enough.");
+    msg = "Pacmod Accel Fault. Not accelerating enough.";
   }
 
   stat.summary(level, msg);


### PR DESCRIPTION
Fix accel/brake fault messages as follows.

Before 
```
Hardware ID: pacmod_checker
Level: ERROR
Message: OK ; Pacmod Accel Fault. Not accelerating enough.
```

After
```
Hardware ID: pacmod_checker
Level: ERROR
Message: Pacmod Accel Fault. Not accelerating enough.
```

(TIERIV Internal Link: https://star4.slack.com/archives/CEV8XMJBV/p1683520621173239?thread_ts=1683509665.471579&cid=CEV8XMJBV )