### PR TITLE
fix: add autoware_internal_msgs

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -3,6 +3,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
     version: main
+  core/autoware_internal_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
+    version: main
   core/common:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git


### PR DESCRIPTION
## Description
Add autoware_internal_msgs to build_depends to fix CI.

https://github.com/tier4/pacmod_interface/actions/runs/9004171745/job/24736533145?pr=68
![image](https://github.com/tier4/pacmod_interface/assets/59680180/43fcfd5e-a3a9-4184-8402-5d1f0e72353f)



## Related PR 
https://github.com/autowarefoundation/autoware.universe/pull/6440/files