### PR TITLE
feat!: replacing autoware_auto_msgs with autoware_msgs

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -11,10 +11,6 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git
     version: main
-  core/external/autoware_auto_msgs:
-    type: git
-    url: https://github.com/tier4/autoware_auto_msgs.git # TODO(Tier IV): Move to autowarefoundation/autoware_msgs
-    version: tier4/main
   universe/autoware:
     type: git
     url: https://github.com/autowarefoundation/autoware.universe

--- a/pacmod_interface/README.md
+++ b/pacmod_interface/README.md
@@ -8,15 +8,15 @@
 
 - From Autoware
 
-  | Name                                   | Type                                                     | Description                                           |
-  | -------------------------------------- | -------------------------------------------------------- | ----------------------------------------------------- |
-  | `/control/command/control_cmd`         | autoware_control_msgs::msg::Control                      | lateral and longitudinal control command              |
-  | `/control/command/gear_cmd`            | autoware_vehicle_msgs::msg::GearCommand             | gear command                                          |
-  | `/control/command/turn_indicators_cmd` | autoware_vehicle_msgs::msg::TurnIndicatorsCommand   | turn indicators command                               |
-  | `/control/command/hazard_lights_cmd`   | autoware_vehicle_msgs::msg::HazardLightsCommand     | hazard lights command                                 |
-  | `/vehicle/engage`                      | autoware_vehicle_msgs::msg::Engage                  | engage command                                        |
-  | `/vehicle/command/actuation_cmd`       | tier4_vehicle_msgs::msg::ActuationCommandStamped         | actuation (accel/brake pedal, steering wheel) command |
-  | `/control/command/emergency_cmd`       | tier4_vehicle_msgs::msg::VehicleEmergencyStamped         | emergency command                                     |
+  | Name                                   | Type                                              | Description                                           |
+  | -------------------------------------- | ------------------------------------------------- | ----------------------------------------------------- |
+  | `/control/command/control_cmd`         | autoware_control_msgs::msg::Control               | lateral and longitudinal control command              |
+  | `/control/command/gear_cmd`            | autoware_vehicle_msgs::msg::GearCommand           | gear command                                          |
+  | `/control/command/turn_indicators_cmd` | autoware_vehicle_msgs::msg::TurnIndicatorsCommand | turn indicators command                               |
+  | `/control/command/hazard_lights_cmd`   | autoware_vehicle_msgs::msg::HazardLightsCommand   | hazard lights command                                 |
+  | `/vehicle/engage`                      | autoware_vehicle_msgs::msg::Engage                | engage command                                        |
+  | `/vehicle/command/actuation_cmd`       | tier4_vehicle_msgs::msg::ActuationCommandStamped  | actuation (accel/brake pedal, steering wheel) command |
+  | `/control/command/emergency_cmd`       | tier4_vehicle_msgs::msg::VehicleEmergencyStamped  | emergency command                                     |
 
 - From Pacmod
 
@@ -45,8 +45,8 @@
 
 - To Autoware
 
-  | Name                                     | Type                                                    | Description                                          |
-  | ---------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------- |
+  | Name                                     | Type                                               | Description                                          |
+  | ---------------------------------------- | -------------------------------------------------- | ---------------------------------------------------- |
   | `/vehicle/status/control_mode`           | autoware_vehicle_msgs::msg::ControlModeReport      | control mode                                         |
   | `/vehicle/status/velocity_status`        | autoware_vehicle_msgs::msg::VelocityReport         | velocity                                             |
   | `/vehicle/status/steering_status`        | autoware_vehicle_msgs::msg::SteeringReport         | steering wheel angle                                 |

--- a/pacmod_interface/README.md
+++ b/pacmod_interface/README.md
@@ -11,10 +11,10 @@
   | Name                                   | Type                                                     | Description                                           |
   | -------------------------------------- | -------------------------------------------------------- | ----------------------------------------------------- |
   | `/control/command/control_cmd`         | autoware_control_msgs::msg::Control                      | lateral and longitudinal control command              |
-  | `/control/command/gear_cmd`            | autoware_auto_vehicle_msgs::msg::GearCommand             | gear command                                          |
-  | `/control/command/turn_indicators_cmd` | autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand   | turn indicators command                               |
-  | `/control/command/hazard_lights_cmd`   | autoware_auto_vehicle_msgs::msg::HazardLightsCommand     | hazard lights command                                 |
-  | `/vehicle/engage`                      | autoware_auto_vehicle_msgs::msg::Engage                  | engage command                                        |
+  | `/control/command/gear_cmd`            | autoware_vehicle_msgs::msg::GearCommand             | gear command                                          |
+  | `/control/command/turn_indicators_cmd` | autoware_vehicle_msgs::msg::TurnIndicatorsCommand   | turn indicators command                               |
+  | `/control/command/hazard_lights_cmd`   | autoware_vehicle_msgs::msg::HazardLightsCommand     | hazard lights command                                 |
+  | `/vehicle/engage`                      | autoware_vehicle_msgs::msg::Engage                  | engage command                                        |
   | `/vehicle/command/actuation_cmd`       | tier4_vehicle_msgs::msg::ActuationCommandStamped         | actuation (accel/brake pedal, steering wheel) command |
   | `/control/command/emergency_cmd`       | tier4_vehicle_msgs::msg::VehicleEmergencyStamped         | emergency command                                     |
 
@@ -47,13 +47,13 @@
 
   | Name                                     | Type                                                    | Description                                          |
   | ---------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------- |
-  | `/vehicle/status/control_mode`           | autoware_auto_vehicle_msgs::msg::ControlModeReport      | control mode                                         |
-  | `/vehicle/status/velocity_status`        | autoware_auto_vehicle_msgs::msg::VelocityReport         | velocity                                             |
-  | `/vehicle/status/steering_status`        | autoware_auto_vehicle_msgs::msg::SteeringReport         | steering wheel angle                                 |
-  | `/vehicle/status/gear_status`            | autoware_auto_vehicle_msgs::msg::GearReport             | gear status                                          |
-  | `/vehicle/status/turn_indicators_status` | autoware_auto_vehicle_msgs::msg::TurnIndicatorsReport   | turn indicators status                               |
-  | `/vehicle/status/hazard_lights_status`   | autoware_auto_vehicle_msgs::msg::HazardLightsReport     | hazard lights status                                 |
-  | `/vehicle/status/actuation_status`       | autoware_auto_vehicle_msgs::msg::ActuationStatusStamped | actuation (accel/brake pedal, steering wheel) status |
+  | `/vehicle/status/control_mode`           | autoware_vehicle_msgs::msg::ControlModeReport      | control mode                                         |
+  | `/vehicle/status/velocity_status`        | autoware_vehicle_msgs::msg::VelocityReport         | velocity                                             |
+  | `/vehicle/status/steering_status`        | autoware_vehicle_msgs::msg::SteeringReport         | steering wheel angle                                 |
+  | `/vehicle/status/gear_status`            | autoware_vehicle_msgs::msg::GearReport             | gear status                                          |
+  | `/vehicle/status/turn_indicators_status` | autoware_vehicle_msgs::msg::TurnIndicatorsReport   | turn indicators status                               |
+  | `/vehicle/status/hazard_lights_status`   | autoware_vehicle_msgs::msg::HazardLightsReport     | hazard lights status                                 |
+  | `/vehicle/status/actuation_status`       | autoware_vehicle_msgs::msg::ActuationStatusStamped | actuation (accel/brake pedal, steering wheel) status |
 
 ## ROS Parameters
 

--- a/pacmod_interface/README.md
+++ b/pacmod_interface/README.md
@@ -10,7 +10,7 @@
 
   | Name                                   | Type                                                     | Description                                           |
   | -------------------------------------- | -------------------------------------------------------- | ----------------------------------------------------- |
-  | `/control/command/control_cmd`         | autoware_auto_control_msgs::msg::AckermannControlCommand | lateral and longitudinal control command              |
+  | `/control/command/control_cmd`         | autoware_control_msgs::msg::Control                      | lateral and longitudinal control command              |
   | `/control/command/gear_cmd`            | autoware_auto_vehicle_msgs::msg::GearCommand             | gear command                                          |
   | `/control/command/turn_indicators_cmd` | autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand   | turn indicators command                               |
   | `/control/command/hazard_lights_cmd`   | autoware_auto_vehicle_msgs::msg::HazardLightsCommand     | hazard lights command                                 |

--- a/pacmod_interface/include/pacmod_interface/pacmod_diag_publisher.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_diag_publisher.hpp
@@ -18,7 +18,7 @@
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <can_msgs/msg/frame.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -42,7 +42,7 @@
 #include <utility>
 #include <vector>
 
-using autoware_auto_control_msgs::msg::AckermannControlCommand;
+using autoware_control_msgs::msg::Control;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
 
@@ -76,7 +76,7 @@ private:
 
   // Acceleration-related Topics
   rclcpp::Subscription<AccelWithCovarianceStamped>::SharedPtr current_acc_sub_;
-  rclcpp::Subscription<AckermannControlCommand>::SharedPtr control_cmd_sub_;
+  rclcpp::Subscription<Control>::SharedPtr control_cmd_sub_;
   rclcpp::Subscription<Odometry>::SharedPtr odom_sub_;
 
   /* ros parameters */
@@ -122,7 +122,7 @@ private:
 
   void callbackAccel(const AccelWithCovarianceStamped::ConstSharedPtr accel);
   void callbackOdometry(const Odometry::SharedPtr odom);
-  void callbackControlCmd(const AckermannControlCommand::ConstSharedPtr control_cmd);
+  void callbackControlCmd(const Control::ConstSharedPtr control_cmd);
 
   /* functions */
   void checkPacmodMsgs(diagnostic_updater::DiagnosticStatusWrapper & stat);

--- a/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
@@ -19,7 +19,7 @@
 #include <tier4_api_utils/tier4_api_utils.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
-#include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_auto_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_auto_vehicle_msgs/msg/engage.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
@@ -74,7 +74,7 @@ private:
 
   /* subscribers */
   // From Autoware
-  rclcpp::Subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
+  rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr
     control_cmd_sub_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::GearCommand>::SharedPtr gear_cmd_sub_;
   rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand>::SharedPtr
@@ -169,7 +169,7 @@ private:
 
   /* input values */
   ActuationCommandStamped::ConstSharedPtr actuation_cmd_ptr_;
-  autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr control_cmd_ptr_;
+  autoware_control_msgs::msg::Control::ConstSharedPtr control_cmd_ptr_;
   autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand::ConstSharedPtr turn_indicators_cmd_ptr_;
   autoware_auto_vehicle_msgs::msg::HazardLightsCommand::ConstSharedPtr hazard_lights_cmd_ptr_;
   autoware_auto_vehicle_msgs::msg::GearCommand::ConstSharedPtr gear_cmd_ptr_;
@@ -194,7 +194,7 @@ private:
   /* callbacks */
   void callbackActuationCmd(const ActuationCommandStamped::ConstSharedPtr msg);
   void callbackControlCmd(
-    const autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr msg);
+    const autoware_control_msgs::msg::Control::ConstSharedPtr msg);
 
   void callbackEmergencyCmd(
     const tier4_vehicle_msgs::msg::VehicleEmergencyStamped::ConstSharedPtr msg);

--- a/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
@@ -20,17 +20,17 @@
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
 #include <autoware_control_msgs/msg/control.hpp>
-#include <autoware_auto_vehicle_msgs/msg/control_mode_report.hpp>
-#include <autoware_auto_vehicle_msgs/msg/engage.hpp>
-#include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
-#include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
-#include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
-#include <autoware_auto_vehicle_msgs/msg/hazard_lights_report.hpp>
-#include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
-#include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
-#include <autoware_auto_vehicle_msgs/msg/turn_indicators_report.hpp>
-#include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
-#include <autoware_auto_vehicle_msgs/srv/control_mode_command.hpp>
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
+#include <autoware_vehicle_msgs/msg/engage.hpp>
+#include <autoware_vehicle_msgs/msg/gear_command.hpp>
+#include <autoware_vehicle_msgs/msg/gear_report.hpp>
+#include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
+#include <autoware_vehicle_msgs/msg/hazard_lights_report.hpp>
+#include <autoware_vehicle_msgs/msg/steering_report.hpp>
+#include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
+#include <autoware_vehicle_msgs/msg/turn_indicators_report.hpp>
+#include <autoware_vehicle_msgs/msg/velocity_report.hpp>
+#include <autoware_vehicle_msgs/srv/control_mode_command.hpp>
 #include <pacmod3_msgs/msg/global_rpt.hpp>
 #include <pacmod3_msgs/msg/steering_cmd.hpp>
 #include <pacmod3_msgs/msg/system_cmd_float.hpp>
@@ -62,7 +62,7 @@ public:
   using ActuationCommandStamped = tier4_vehicle_msgs::msg::ActuationCommandStamped;
   using ActuationStatusStamped = tier4_vehicle_msgs::msg::ActuationStatusStamped;
   using SteeringWheelStatusStamped = tier4_vehicle_msgs::msg::SteeringWheelStatusStamped;
-  using ControlModeCommand = autoware_auto_vehicle_msgs::srv::ControlModeCommand;
+  using ControlModeCommand = autoware_vehicle_msgs::srv::ControlModeCommand;
   PacmodInterface();
 
 private:
@@ -76,10 +76,10 @@ private:
   // From Autoware
   rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr
     control_cmd_sub_;
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::GearCommand>::SharedPtr gear_cmd_sub_;
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand>::SharedPtr
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::GearCommand>::SharedPtr gear_cmd_sub_;
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>::SharedPtr
     turn_indicators_cmd_sub_;
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
     hazard_lights_cmd_sub_;
   rclcpp::Subscription<ActuationCommandStamped>::SharedPtr actuation_cmd_sub_;
   rclcpp::Subscription<tier4_vehicle_msgs::msg::VehicleEmergencyStamped>::SharedPtr emergency_sub_;
@@ -110,15 +110,15 @@ private:
     raw_steer_cmd_pub_;  // only for debug
 
   // To Autoware
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::ControlModeReport>::SharedPtr
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::ControlModeReport>::SharedPtr
     control_mode_pub_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::VelocityReport>::SharedPtr vehicle_twist_pub_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::SteeringReport>::SharedPtr
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::VelocityReport>::SharedPtr vehicle_twist_pub_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::SteeringReport>::SharedPtr
     steering_status_pub_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::GearReport>::SharedPtr gear_status_pub_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::TurnIndicatorsReport>::SharedPtr
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::GearReport>::SharedPtr gear_status_pub_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnIndicatorsReport>::SharedPtr
     turn_indicators_status_pub_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::HazardLightsReport>::SharedPtr
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::HazardLightsReport>::SharedPtr
     hazard_lights_status_pub_;
   rclcpp::Publisher<ActuationStatusStamped>::SharedPtr actuation_status_pub_;
   rclcpp::Publisher<SteeringWheelStatusStamped>::SharedPtr steering_wheel_status_pub_;
@@ -170,9 +170,9 @@ private:
   /* input values */
   ActuationCommandStamped::ConstSharedPtr actuation_cmd_ptr_;
   autoware_control_msgs::msg::Control::ConstSharedPtr control_cmd_ptr_;
-  autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand::ConstSharedPtr turn_indicators_cmd_ptr_;
-  autoware_auto_vehicle_msgs::msg::HazardLightsCommand::ConstSharedPtr hazard_lights_cmd_ptr_;
-  autoware_auto_vehicle_msgs::msg::GearCommand::ConstSharedPtr gear_cmd_ptr_;
+  autoware_vehicle_msgs::msg::TurnIndicatorsCommand::ConstSharedPtr turn_indicators_cmd_ptr_;
+  autoware_vehicle_msgs::msg::HazardLightsCommand::ConstSharedPtr hazard_lights_cmd_ptr_;
+  autoware_vehicle_msgs::msg::GearCommand::ConstSharedPtr gear_cmd_ptr_;
 
   pacmod3_msgs::msg::SystemRptFloat::ConstSharedPtr steer_wheel_rpt_ptr_;  // [rad]
   pacmod3_msgs::msg::WheelSpeedRpt::ConstSharedPtr wheel_speed_rpt_ptr_;   // [m/s]
@@ -199,12 +199,12 @@ private:
   void callbackEmergencyCmd(
     const tier4_vehicle_msgs::msg::VehicleEmergencyStamped::ConstSharedPtr msg);
 
-  void callbackGearCmd(const autoware_auto_vehicle_msgs::msg::GearCommand::ConstSharedPtr msg);
+  void callbackGearCmd(const autoware_vehicle_msgs::msg::GearCommand::ConstSharedPtr msg);
   void callbackTurnIndicatorsCommand(
-    const autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand::ConstSharedPtr msg);
+    const autoware_vehicle_msgs::msg::TurnIndicatorsCommand::ConstSharedPtr msg);
   void callbackHazardLightsCommand(
-    const autoware_auto_vehicle_msgs::msg::HazardLightsCommand::ConstSharedPtr msg);
-  void callbackEngage(const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
+    const autoware_vehicle_msgs::msg::HazardLightsCommand::ConstSharedPtr msg);
+  void callbackEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
   void callbackRearDoor(const pacmod3_msgs::msg::SystemRptInt::ConstSharedPtr rear_door_rpt);
   void callbackPacmodRpt(
     const pacmod3_msgs::msg::SystemRptFloat::ConstSharedPtr steer_wheel_rpt,
@@ -222,14 +222,14 @@ private:
     const pacmod3_msgs::msg::SystemRptInt & shift_rpt);
   double calculateVariableGearRatio(const double vel, const double steer_wheel);
   double calcSteerWheelRateCmd(const double gear_ratio);
-  uint16_t toPacmodShiftCmd(const autoware_auto_vehicle_msgs::msg::GearCommand & gear_cmd);
+  uint16_t toPacmodShiftCmd(const autoware_vehicle_msgs::msg::GearCommand & gear_cmd);
   uint16_t getGearCmdForPreventChatter(uint16_t gear_command);
   uint16_t toPacmodTurnCmd(
-    const autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand & turn,
-    const autoware_auto_vehicle_msgs::msg::HazardLightsCommand & hazard);
+    const autoware_vehicle_msgs::msg::TurnIndicatorsCommand & turn,
+    const autoware_vehicle_msgs::msg::HazardLightsCommand & hazard);
   uint16_t toPacmodTurnCmdWithHazardRecover(
-    const autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand & turn,
-    const autoware_auto_vehicle_msgs::msg::HazardLightsCommand & hazard);
+    const autoware_vehicle_msgs::msg::TurnIndicatorsCommand & turn,
+    const autoware_vehicle_msgs::msg::HazardLightsCommand & hazard);
 
   std::optional<int32_t> toAutowareShiftReport(const pacmod3_msgs::msg::SystemRptInt & shift);
   int32_t toAutowareTurnIndicatorsReport(const pacmod3_msgs::msg::SystemRptInt & turn);

--- a/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
@@ -64,8 +64,7 @@ public:
 private:
   /* subscribers */
   // From Autoware
-  rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr
-    control_cmd_sub_;
+  rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr control_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::GearCommand>::SharedPtr gear_cmd_sub_;
   rclcpp::Subscription<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>::SharedPtr
     turn_indicators_cmd_sub_;
@@ -97,11 +96,9 @@ private:
     raw_steer_cmd_pub_;  // only for debug
 
   // To Autoware
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::ControlModeReport>::SharedPtr
-    control_mode_pub_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::ControlModeReport>::SharedPtr control_mode_pub_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::VelocityReport>::SharedPtr vehicle_twist_pub_;
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::SteeringReport>::SharedPtr
-    steering_status_pub_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::SteeringReport>::SharedPtr steering_status_pub_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::GearReport>::SharedPtr gear_status_pub_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnIndicatorsReport>::SharedPtr
     turn_indicators_status_pub_;
@@ -188,8 +185,7 @@ private:
 
   /* callbacks */
   void callbackActuationCmd(const ActuationCommandStamped::ConstSharedPtr msg);
-  void callbackControlCmd(
-    const autoware_control_msgs::msg::Control::ConstSharedPtr msg);
+  void callbackControlCmd(const autoware_control_msgs::msg::Control::ConstSharedPtr msg);
 
   void callbackEmergencyCmd(
     const tier4_vehicle_msgs::msg::VehicleEmergencyStamped::ConstSharedPtr msg);

--- a/pacmod_interface/include/pacmod_steer_test/pacmod_steer_test.hpp
+++ b/pacmod_interface/include/pacmod_steer_test/pacmod_steer_test.hpp
@@ -18,13 +18,13 @@
 #include <rclcpp/rclcpp.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
-#include <autoware_auto_vehicle_msgs/msg/control_mode_report.hpp>
-#include <autoware_auto_vehicle_msgs/msg/engage.hpp>
-#include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
-#include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
-#include <autoware_auto_vehicle_msgs/msg/turn_indicators_report.hpp>
-#include <autoware_auto_vehicle_msgs/msg/vehicle_control_command.hpp>
-#include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
+#include <autoware_vehicle_msgs/msg/engage.hpp>
+#include <autoware_vehicle_msgs/msg/gear_report.hpp>
+#include <autoware_vehicle_msgs/msg/steering_report.hpp>
+#include <autoware_vehicle_msgs/msg/turn_indicators_report.hpp>
+#include <autoware_vehicle_msgs/msg/vehicle_control_command.hpp>
+#include <autoware_vehicle_msgs/msg/velocity_report.hpp>
 #include <pacmod3_msgs/msg/global_rpt.hpp>
 #include <pacmod3_msgs/msg/steering_cmd.hpp>
 #include <pacmod3_msgs/msg/system_cmd_float.hpp>
@@ -57,7 +57,7 @@ private:
 
   /* subscribers */
   // From Autoware
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::Engage>::SharedPtr engage_cmd_sub_;
+  rclcpp::Subscription<autoware_vehicle_msgs::msg::Engage>::SharedPtr engage_cmd_sub_;
 
   // From Pacmod
   std::unique_ptr<message_filters::Subscriber<pacmod3_msgs::msg::SystemRptFloat>>
@@ -80,13 +80,13 @@ private:
   rclcpp::Publisher<pacmod3_msgs::msg::SystemCmdInt>::SharedPtr turn_cmd_pub_;
 
   // output vehicle info
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::ControlModeReport>::SharedPtr
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::ControlModeReport>::SharedPtr
     control_mode_pub_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::VelocityReport>::SharedPtr vehicle_twist_pub_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::SteeringReport>::SharedPtr
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::VelocityReport>::SharedPtr vehicle_twist_pub_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::SteeringReport>::SharedPtr
     steering_status_pub_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::GearReport>::SharedPtr shift_status_pub_;
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::TurnIndicatorsReport>::SharedPtr
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::GearReport>::SharedPtr shift_status_pub_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnIndicatorsReport>::SharedPtr
     turn_signal_status_pub_;
 
   vehicle_info_util::VehicleInfo vehicle_info_;
@@ -118,7 +118,7 @@ private:
   bool engage_cmd_ = false;
 
   /* callbacks */
-  void callbackEngage(const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
+  void callbackEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg);
   void callbackPacmodRpt(
     const pacmod3_msgs::msg::SystemRptFloat::ConstSharedPtr steer_wheel_rpt,
     const pacmod3_msgs::msg::WheelSpeedRpt::ConstSharedPtr wheel_speed_rpt,

--- a/pacmod_interface/include/pacmod_steer_test/pacmod_steer_test.hpp
+++ b/pacmod_interface/include/pacmod_steer_test/pacmod_steer_test.hpp
@@ -79,11 +79,9 @@ private:
   rclcpp::Publisher<pacmod3_msgs::msg::SystemCmdInt>::SharedPtr turn_cmd_pub_;
 
   // output vehicle info
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::ControlModeReport>::SharedPtr
-    control_mode_pub_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::ControlModeReport>::SharedPtr control_mode_pub_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::VelocityReport>::SharedPtr vehicle_twist_pub_;
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::SteeringReport>::SharedPtr
-    steering_status_pub_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::SteeringReport>::SharedPtr steering_status_pub_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::GearReport>::SharedPtr shift_status_pub_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnIndicatorsReport>::SharedPtr
     turn_signal_status_pub_;

--- a/pacmod_interface/include/pacmod_steer_test/pacmod_steer_test.hpp
+++ b/pacmod_interface/include/pacmod_steer_test/pacmod_steer_test.hpp
@@ -23,7 +23,6 @@
 #include <autoware_vehicle_msgs/msg/gear_report.hpp>
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_report.hpp>
-#include <autoware_vehicle_msgs/msg/vehicle_control_command.hpp>
 #include <autoware_vehicle_msgs/msg/velocity_report.hpp>
 #include <pacmod3_msgs/msg/global_rpt.hpp>
 #include <pacmod3_msgs/msg/steering_cmd.hpp>

--- a/pacmod_interface/package.xml
+++ b/pacmod_interface/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>autoware_auto_control_msgs</depend>
+  <depend>autoware_control_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>can_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/pacmod_interface/package.xml
+++ b/pacmod_interface/package.xml
@@ -14,7 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>autoware_control_msgs</depend>
-  <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>can_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>

--- a/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
@@ -119,8 +119,7 @@ void PacmodDiagPublisher::callbackAccel(const AccelWithCovarianceStamped::ConstS
   addValueToQue(acc_que_, accel->accel.accel.linear.x, accel->header.stamp, accel_store_time_);
 }
 
-void PacmodDiagPublisher::callbackControlCmd(
-  const Control::ConstSharedPtr control_cmd)
+void PacmodDiagPublisher::callbackControlCmd(const Control::ConstSharedPtr control_cmd)
 {
   addValueToQue(
     acc_cmd_que_, control_cmd->longitudinal.acceleration, control_cmd->stamp, accel_store_time_);

--- a/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_diag_publisher.cpp
@@ -80,7 +80,7 @@ PacmodDiagPublisher::PacmodDiagPublisher()
   current_acc_sub_ = create_subscription<AccelWithCovarianceStamped>(
     "/localization/acceleration", 1,
     std::bind(&PacmodDiagPublisher::callbackAccel, this, std::placeholders::_1));
-  control_cmd_sub_ = create_subscription<AckermannControlCommand>(
+  control_cmd_sub_ = create_subscription<Control>(
     "/control/command/control_cmd", 1,
     std::bind(&PacmodDiagPublisher::callbackControlCmd, this, std::placeholders::_1));
   odom_sub_ = create_subscription<Odometry>(
@@ -120,7 +120,7 @@ void PacmodDiagPublisher::callbackAccel(const AccelWithCovarianceStamped::ConstS
 }
 
 void PacmodDiagPublisher::callbackControlCmd(
-  const AckermannControlCommand::ConstSharedPtr control_cmd)
+  const Control::ConstSharedPtr control_cmd)
 {
   addValueToQue(
     acc_cmd_que_, control_cmd->longitudinal.acceleration, control_cmd->stamp, accel_store_time_);

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
@@ -70,7 +70,7 @@ PacmodInterface::PacmodInterface()
   using std::placeholders::_2;
 
   // From autoware
-  control_cmd_sub_ = create_subscription<autoware_auto_control_msgs::msg::AckermannControlCommand>(
+  control_cmd_sub_ = create_subscription<autoware_control_msgs::msg::Control>(
     "/control/command/control_cmd", 1, std::bind(&PacmodInterface::callbackControlCmd, this, _1));
   gear_cmd_sub_ = create_subscription<autoware_auto_vehicle_msgs::msg::GearCommand>(
     "/control/command/gear_cmd", 1, std::bind(&PacmodInterface::callbackGearCmd, this, _1));
@@ -187,7 +187,7 @@ void PacmodInterface::callbackEmergencyCmd(
 }
 
 void PacmodInterface::callbackControlCmd(
-  const autoware_auto_control_msgs::msg::AckermannControlCommand::ConstSharedPtr msg)
+  const autoware_control_msgs::msg::Control::ConstSharedPtr msg)
 {
   control_command_received_time_ = this->now();
   control_cmd_ptr_ = msg;

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
@@ -74,14 +74,12 @@ PacmodInterface::PacmodInterface()
     "/control/command/control_cmd", 1, std::bind(&PacmodInterface::callbackControlCmd, this, _1));
   gear_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::GearCommand>(
     "/control/command/gear_cmd", 1, std::bind(&PacmodInterface::callbackGearCmd, this, _1));
-  turn_indicators_cmd_sub_ =
-    create_subscription<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>(
-      "/control/command/turn_indicators_cmd", rclcpp::QoS{1},
-      std::bind(&PacmodInterface::callbackTurnIndicatorsCommand, this, _1));
-  hazard_lights_cmd_sub_ =
-    create_subscription<autoware_vehicle_msgs::msg::HazardLightsCommand>(
-      "/control/command/hazard_lights_cmd", rclcpp::QoS{1},
-      std::bind(&PacmodInterface::callbackHazardLightsCommand, this, _1));
+  turn_indicators_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>(
+    "/control/command/turn_indicators_cmd", rclcpp::QoS{1},
+    std::bind(&PacmodInterface::callbackTurnIndicatorsCommand, this, _1));
+  hazard_lights_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::HazardLightsCommand>(
+    "/control/command/hazard_lights_cmd", rclcpp::QoS{1},
+    std::bind(&PacmodInterface::callbackHazardLightsCommand, this, _1));
 
   actuation_cmd_sub_ = create_subscription<ActuationCommandStamped>(
     "/control/command/actuation_cmd", 1,
@@ -137,9 +135,8 @@ PacmodInterface::PacmodInterface()
     "/vehicle/status/steering_status", rclcpp::QoS{1});
   gear_status_pub_ = create_publisher<autoware_vehicle_msgs::msg::GearReport>(
     "/vehicle/status/gear_status", rclcpp::QoS{1});
-  turn_indicators_status_pub_ =
-    create_publisher<autoware_vehicle_msgs::msg::TurnIndicatorsReport>(
-      "/vehicle/status/turn_indicators_status", rclcpp::QoS{1});
+  turn_indicators_status_pub_ = create_publisher<autoware_vehicle_msgs::msg::TurnIndicatorsReport>(
+    "/vehicle/status/turn_indicators_status", rclcpp::QoS{1});
   hazard_lights_status_pub_ = create_publisher<autoware_vehicle_msgs::msg::HazardLightsReport>(
     "/vehicle/status/hazard_lights_status", rclcpp::QoS{1});
   actuation_status_pub_ =
@@ -601,8 +598,7 @@ double PacmodInterface::calculateVariableGearRatio(const double vel, const doubl
     1e-5, vgr_coef_a_ + vgr_coef_b_ * vel * vel - vgr_coef_c_ * std::fabs(steer_wheel));
 }
 
-uint16_t PacmodInterface::toPacmodShiftCmd(
-  const autoware_vehicle_msgs::msg::GearCommand & gear_cmd)
+uint16_t PacmodInterface::toPacmodShiftCmd(const autoware_vehicle_msgs::msg::GearCommand & gear_cmd)
 {
   using pacmod3_msgs::msg::SystemCmdInt;
 

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
@@ -72,14 +72,14 @@ PacmodInterface::PacmodInterface()
   // From autoware
   control_cmd_sub_ = create_subscription<autoware_control_msgs::msg::Control>(
     "/control/command/control_cmd", 1, std::bind(&PacmodInterface::callbackControlCmd, this, _1));
-  gear_cmd_sub_ = create_subscription<autoware_auto_vehicle_msgs::msg::GearCommand>(
+  gear_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::GearCommand>(
     "/control/command/gear_cmd", 1, std::bind(&PacmodInterface::callbackGearCmd, this, _1));
   turn_indicators_cmd_sub_ =
-    create_subscription<autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand>(
+    create_subscription<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>(
       "/control/command/turn_indicators_cmd", rclcpp::QoS{1},
       std::bind(&PacmodInterface::callbackTurnIndicatorsCommand, this, _1));
   hazard_lights_cmd_sub_ =
-    create_subscription<autoware_auto_vehicle_msgs::msg::HazardLightsCommand>(
+    create_subscription<autoware_vehicle_msgs::msg::HazardLightsCommand>(
       "/control/command/hazard_lights_cmd", rclcpp::QoS{1},
       std::bind(&PacmodInterface::callbackHazardLightsCommand, this, _1));
 
@@ -141,18 +141,18 @@ PacmodInterface::PacmodInterface()
     "/pacmod/raw_steer_cmd", rclcpp::QoS{1});  // only for debug
 
   // To Autoware
-  control_mode_pub_ = create_publisher<autoware_auto_vehicle_msgs::msg::ControlModeReport>(
+  control_mode_pub_ = create_publisher<autoware_vehicle_msgs::msg::ControlModeReport>(
     "/vehicle/status/control_mode", rclcpp::QoS{1});
-  vehicle_twist_pub_ = create_publisher<autoware_auto_vehicle_msgs::msg::VelocityReport>(
+  vehicle_twist_pub_ = create_publisher<autoware_vehicle_msgs::msg::VelocityReport>(
     "/vehicle/status/velocity_status", rclcpp::QoS{1});
-  steering_status_pub_ = create_publisher<autoware_auto_vehicle_msgs::msg::SteeringReport>(
+  steering_status_pub_ = create_publisher<autoware_vehicle_msgs::msg::SteeringReport>(
     "/vehicle/status/steering_status", rclcpp::QoS{1});
-  gear_status_pub_ = create_publisher<autoware_auto_vehicle_msgs::msg::GearReport>(
+  gear_status_pub_ = create_publisher<autoware_vehicle_msgs::msg::GearReport>(
     "/vehicle/status/gear_status", rclcpp::QoS{1});
   turn_indicators_status_pub_ =
-    create_publisher<autoware_auto_vehicle_msgs::msg::TurnIndicatorsReport>(
+    create_publisher<autoware_vehicle_msgs::msg::TurnIndicatorsReport>(
       "/vehicle/status/turn_indicators_status", rclcpp::QoS{1});
-  hazard_lights_status_pub_ = create_publisher<autoware_auto_vehicle_msgs::msg::HazardLightsReport>(
+  hazard_lights_status_pub_ = create_publisher<autoware_vehicle_msgs::msg::HazardLightsReport>(
     "/vehicle/status/hazard_lights_status", rclcpp::QoS{1});
   actuation_status_pub_ =
     create_publisher<ActuationStatusStamped>("/vehicle/status/actuation_status", 1);
@@ -194,19 +194,19 @@ void PacmodInterface::callbackControlCmd(
 }
 
 void PacmodInterface::callbackGearCmd(
-  const autoware_auto_vehicle_msgs::msg::GearCommand::ConstSharedPtr msg)
+  const autoware_vehicle_msgs::msg::GearCommand::ConstSharedPtr msg)
 {
   gear_cmd_ptr_ = msg;
 }
 
 void PacmodInterface::callbackTurnIndicatorsCommand(
-  const autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand::ConstSharedPtr msg)
+  const autoware_vehicle_msgs::msg::TurnIndicatorsCommand::ConstSharedPtr msg)
 {
   turn_indicators_cmd_ptr_ = msg;
 }
 
 void PacmodInterface::callbackHazardLightsCommand(
-  const autoware_auto_vehicle_msgs::msg::HazardLightsCommand::ConstSharedPtr msg)
+  const autoware_vehicle_msgs::msg::HazardLightsCommand::ConstSharedPtr msg)
 {
   hazard_lights_cmd_ptr_ = msg;
 }
@@ -290,13 +290,13 @@ void PacmodInterface::callbackPacmodRpt(
 
   /* publish vehicle status control_mode */
   {
-    autoware_auto_vehicle_msgs::msg::ControlModeReport control_mode_msg;
+    autoware_vehicle_msgs::msg::ControlModeReport control_mode_msg;
     control_mode_msg.stamp = header.stamp;
 
     if (global_rpt->enabled && is_pacmod_enabled_) {
-      control_mode_msg.mode = autoware_auto_vehicle_msgs::msg::ControlModeReport::AUTONOMOUS;
+      control_mode_msg.mode = autoware_vehicle_msgs::msg::ControlModeReport::AUTONOMOUS;
     } else {
-      control_mode_msg.mode = autoware_auto_vehicle_msgs::msg::ControlModeReport::MANUAL;
+      control_mode_msg.mode = autoware_vehicle_msgs::msg::ControlModeReport::MANUAL;
     }
 
     control_mode_pub_->publish(control_mode_msg);
@@ -304,7 +304,7 @@ void PacmodInterface::callbackPacmodRpt(
 
   /* publish vehicle status twist */
   {
-    autoware_auto_vehicle_msgs::msg::VelocityReport twist;
+    autoware_vehicle_msgs::msg::VelocityReport twist;
     twist.header = header;
     twist.longitudinal_velocity = current_velocity;                                 // [m/s]
     twist.heading_rate = current_velocity * std::tan(current_steer) / wheel_base_;  // [rad/s]
@@ -313,7 +313,7 @@ void PacmodInterface::callbackPacmodRpt(
 
   /* publish current shift */
   {
-    autoware_auto_vehicle_msgs::msg::GearReport gear_report_msg;
+    autoware_vehicle_msgs::msg::GearReport gear_report_msg;
     gear_report_msg.stamp = header.stamp;
     const auto opt_gear_report = toAutowareShiftReport(*gear_cmd_rpt_ptr_);
     if (opt_gear_report) {
@@ -324,7 +324,7 @@ void PacmodInterface::callbackPacmodRpt(
 
   /* publish current status */
   {
-    autoware_auto_vehicle_msgs::msg::SteeringReport steer_msg;
+    autoware_vehicle_msgs::msg::SteeringReport steer_msg;
     steer_msg.stamp = header.stamp;
     steer_msg.steering_tire_angle = current_steer;
     steering_status_pub_->publish(steer_msg);
@@ -342,12 +342,12 @@ void PacmodInterface::callbackPacmodRpt(
 
   /* publish current turn signal */
   {
-    autoware_auto_vehicle_msgs::msg::TurnIndicatorsReport turn_msg;
+    autoware_vehicle_msgs::msg::TurnIndicatorsReport turn_msg;
     turn_msg.stamp = header.stamp;
     turn_msg.report = toAutowareTurnIndicatorsReport(*turn_rpt);
     turn_indicators_status_pub_->publish(turn_msg);
 
-    autoware_auto_vehicle_msgs::msg::HazardLightsReport hazard_msg;
+    autoware_vehicle_msgs::msg::HazardLightsReport hazard_msg;
     hazard_msg.stamp = header.stamp;
     hazard_msg.report = toAutowareHazardLightsReport(*turn_rpt);
     hazard_lights_status_pub_->publish(hazard_msg);
@@ -574,20 +574,20 @@ double PacmodInterface::calculateVariableGearRatio(const double vel, const doubl
 }
 
 uint16_t PacmodInterface::toPacmodShiftCmd(
-  const autoware_auto_vehicle_msgs::msg::GearCommand & gear_cmd)
+  const autoware_vehicle_msgs::msg::GearCommand & gear_cmd)
 {
   using pacmod3_msgs::msg::SystemCmdInt;
 
-  if (gear_cmd.command == autoware_auto_vehicle_msgs::msg::GearCommand::PARK) {
+  if (gear_cmd.command == autoware_vehicle_msgs::msg::GearCommand::PARK) {
     return SystemCmdInt::SHIFT_PARK;
   }
-  if (gear_cmd.command == autoware_auto_vehicle_msgs::msg::GearCommand::REVERSE) {
+  if (gear_cmd.command == autoware_vehicle_msgs::msg::GearCommand::REVERSE) {
     return SystemCmdInt::SHIFT_REVERSE;
   }
-  if (gear_cmd.command == autoware_auto_vehicle_msgs::msg::GearCommand::DRIVE) {
+  if (gear_cmd.command == autoware_vehicle_msgs::msg::GearCommand::DRIVE) {
     return SystemCmdInt::SHIFT_FORWARD;
   }
-  if (gear_cmd.command == autoware_auto_vehicle_msgs::msg::GearCommand::LOW) {
+  if (gear_cmd.command == autoware_vehicle_msgs::msg::GearCommand::LOW) {
     return SystemCmdInt::SHIFT_LOW;
   }
 
@@ -627,7 +627,7 @@ uint16_t PacmodInterface::getGearCmdForPreventChatter(uint16_t gear_command)
 std::optional<int32_t> PacmodInterface::toAutowareShiftReport(
   const pacmod3_msgs::msg::SystemRptInt & shift)
 {
-  using autoware_auto_vehicle_msgs::msg::GearReport;
+  using autoware_vehicle_msgs::msg::GearReport;
   using pacmod3_msgs::msg::SystemRptInt;
 
   if (shift.output == SystemRptInt::SHIFT_PARK) {
@@ -646,11 +646,11 @@ std::optional<int32_t> PacmodInterface::toAutowareShiftReport(
 }
 
 uint16_t PacmodInterface::toPacmodTurnCmd(
-  const autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand & turn,
-  const autoware_auto_vehicle_msgs::msg::HazardLightsCommand & hazard)
+  const autoware_vehicle_msgs::msg::TurnIndicatorsCommand & turn,
+  const autoware_vehicle_msgs::msg::HazardLightsCommand & hazard)
 {
-  using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
-  using autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand;
+  using autoware_vehicle_msgs::msg::HazardLightsCommand;
+  using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
   using pacmod3_msgs::msg::SystemCmdInt;
 
   // NOTE: hazard lights command has a highest priority here.
@@ -667,8 +667,8 @@ uint16_t PacmodInterface::toPacmodTurnCmd(
 }
 
 uint16_t PacmodInterface::toPacmodTurnCmdWithHazardRecover(
-  const autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand & turn,
-  const autoware_auto_vehicle_msgs::msg::HazardLightsCommand & hazard)
+  const autoware_vehicle_msgs::msg::TurnIndicatorsCommand & turn,
+  const autoware_vehicle_msgs::msg::HazardLightsCommand & hazard)
 {
   using pacmod3_msgs::msg::SystemRptInt;
 
@@ -711,7 +711,7 @@ uint16_t PacmodInterface::toPacmodTurnCmdWithHazardRecover(
 int32_t PacmodInterface::toAutowareTurnIndicatorsReport(
   const pacmod3_msgs::msg::SystemRptInt & turn)
 {
-  using autoware_auto_vehicle_msgs::msg::TurnIndicatorsReport;
+  using autoware_vehicle_msgs::msg::TurnIndicatorsReport;
   using pacmod3_msgs::msg::SystemRptInt;
 
   if (turn.output == SystemRptInt::TURN_RIGHT) {
@@ -727,7 +727,7 @@ int32_t PacmodInterface::toAutowareTurnIndicatorsReport(
 int32_t PacmodInterface::toAutowareHazardLightsReport(
   const pacmod3_msgs::msg::SystemRptInt & hazard)
 {
-  using autoware_auto_vehicle_msgs::msg::HazardLightsReport;
+  using autoware_vehicle_msgs::msg::HazardLightsReport;
   using pacmod3_msgs::msg::SystemRptInt;
 
   if (hazard.output == SystemRptInt::TURN_HAZARDS) {

--- a/pacmod_interface/src/pacmod_steer_test/pacmod_steer_test.cpp
+++ b/pacmod_interface/src/pacmod_steer_test/pacmod_steer_test.cpp
@@ -55,7 +55,7 @@ PacmodSteerTest::PacmodSteerTest()
   using std::placeholders::_1;
 
   // Engage
-  engage_cmd_sub_ = create_subscription<autoware_auto_vehicle_msgs::msg::Engage>(
+  engage_cmd_sub_ = create_subscription<autoware_vehicle_msgs::msg::Engage>(
     "/vehicle/engage", rclcpp::QoS{1}, std::bind(&PacmodSteerTest::callbackEngage, this, _1));
   // From pacmod
   steer_wheel_rpt_sub_ =
@@ -99,9 +99,9 @@ PacmodSteerTest::PacmodSteerTest()
     create_publisher<pacmod3_msgs::msg::SystemCmdInt>("/pacmod/turn_cmd", rclcpp::QoS{1});
 
   // To Autoware
-  vehicle_twist_pub_ = create_publisher<autoware_auto_vehicle_msgs::msg::VelocityReport>(
+  vehicle_twist_pub_ = create_publisher<autoware_vehicle_msgs::msg::VelocityReport>(
     "/vehicle/status/velocity_status", rclcpp::QoS{1});
-  steering_status_pub_ = create_publisher<autoware_auto_vehicle_msgs::msg::SteeringReport>(
+  steering_status_pub_ = create_publisher<autoware_vehicle_msgs::msg::SteeringReport>(
     "/vehicle/status/steering_status", rclcpp::QoS{1});
   // Timer
   auto timer_callback = std::bind(&PacmodSteerTest::publishCommands, this);
@@ -114,7 +114,7 @@ PacmodSteerTest::PacmodSteerTest()
 }
 
 void PacmodSteerTest::callbackEngage(
-  const autoware_auto_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
+  const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
 {
   engage_cmd_ = msg->engage;
   is_clear_override_needed_ = true;
@@ -164,7 +164,7 @@ void PacmodSteerTest::callbackPacmodRpt(
 
   /* publish vehicle status twist */
   {
-    autoware_auto_vehicle_msgs::msg::VelocityReport velocity_report;
+    autoware_vehicle_msgs::msg::VelocityReport velocity_report;
     velocity_report.header = header;
     velocity_report.longitudinal_velocity = current_velocity;  // [m/s]
     velocity_report.heading_rate =
@@ -174,7 +174,7 @@ void PacmodSteerTest::callbackPacmodRpt(
 
   /* publish current steering angle */
   {
-    autoware_auto_vehicle_msgs::msg::SteeringReport steer_msg;
+    autoware_vehicle_msgs::msg::SteeringReport steer_msg;
     steer_msg.stamp = header.stamp;
     steer_msg.steering_tire_angle = current_steer;
     steering_status_pub_->publish(steer_msg);

--- a/pacmod_interface/src/pacmod_steer_test/pacmod_steer_test.cpp
+++ b/pacmod_interface/src/pacmod_steer_test/pacmod_steer_test.cpp
@@ -113,8 +113,7 @@ PacmodSteerTest::PacmodSteerTest()
   this->get_node_timers_interface()->add_timer(timer_, nullptr);
 }
 
-void PacmodSteerTest::callbackEngage(
-  const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
+void PacmodSteerTest::callbackEngage(const autoware_vehicle_msgs::msg::Engage::ConstSharedPtr msg)
 {
   engage_cmd_ = msg->engage;
   is_clear_override_needed_ = true;


### PR DESCRIPTION
This is a duplicate of https://github.com/tier4/pacmod_interface/pull/77 because pre-commit ci didn't have privilege to make changes to the feature branch.  

Related to the following [change from autoware_auto_msgs to autoware_msgs](https://github.com/orgs/autowarefoundation/discussions/3862).