### PR TITLE
chore: update package prefix for load param

### DIFF
--- a/pacmod_interface/launch/pacmod_interface.launch.xml
+++ b/pacmod_interface/launch/pacmod_interface.launch.xml
@@ -5,7 +5,7 @@
   <arg name="pacmod_diag_publisher_param_path" default="$(find-pkg-share pacmod_interface)/config/pacmod_diag_publisher.param.yaml"/>
 
   <!-- vehicle info -->
-  <arg name="vehicle_info_param_file" default="$(find-pkg-share vehicle_info_util)/config/vehicle_info.param.yaml"/>
+  <arg name="vehicle_info_param_file" default="$(find-pkg-share autoware_vehicle_info_utils)/config/vehicle_info.param.yaml"/>
 
   <!-- pacmod interface -->
   <node pkg="pacmod_interface" exec="pacmod_interface" name="pacmod_interface" output="screen">


### PR DESCRIPTION
change `vehicle_Info_util` -> `autoware_vehicle_info_utils`

Related PR of https://github.com/autowarefoundation/autoware.universe/pull/7353 and https://github.com/tier4/pacmod_interface/commit/329ebfdd2e59ae68b0bb4d82c3733757443efc79