### PR TITLE
feat(pacmod_interface): add option to receive steering wheel command directly

### DIFF
--- a/pacmod_interface/config/pacmod.param.yaml
+++ b/pacmod_interface/config/pacmod.param.yaml
@@ -19,3 +19,5 @@
     accel_pedal_offset: 0.0
     brake_pedal_offset: 0.0
     margin_time_for_gear_change: 2.0
+    enable_pub_steer: true
+    convert_steer_command: true

--- a/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
+++ b/pacmod_interface/include/pacmod_interface/pacmod_interface.hpp
@@ -159,6 +159,13 @@ private:
 
   double margin_time_for_gear_change_;  // [s]
 
+  // steer command conversion
+  // if false, it is expected to be converted from and published actuation_status in
+  // raw_vehicle_cmd_converter
+  bool enable_pub_steer_ = true;  // flag to publish steer_cmd
+  // if false, it is expected to be converted from and published actuation_status in
+  bool convert_steer_command_ = true;  // flag to convert steer command
+
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
 
   // Service

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
@@ -411,7 +411,8 @@ void PacmodInterface::publishCommands()
       // NOTE:
       // It is assumed that steer_cmd is send as actuation_cmd without being converted from
       // raw_vehicle_cmd_converter.
-      desired_steer_wheel = (actuation.steer_cmd - steering_offset_) * adaptive_gear_ratio;
+      desired_steer_wheel =
+        (actuation_cmd_ptr_->actuation.steer_cmd - steering_offset_) * adaptive_gear_ratio;
     } else {
       desired_steer_wheel = actuation_cmd_ptr_->actuation.steer_cmd;
     }

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
@@ -408,8 +408,10 @@ void PacmodInterface::publishCommands()
   const double desired_steer_wheel = std::invoke([&]() -> double {
     double desired_steer_wheel{0.0};
     if (convert_steer_command_) {
-      desired_steer_wheel =
-        (control_cmd_ptr_->lateral.steering_tire_angle - steering_offset_) * adaptive_gear_ratio;
+      // NOTE:
+      // It is assumed that steer_cmd is send as actuation_cmd without being converted from
+      // raw_vehicle_cmd_converter.
+      desired_steer_wheel = (actuation.steer_cmd - steering_offset_) * adaptive_gear_ratio;
     } else {
       desired_steer_wheel = actuation_cmd_ptr_->actuation.steer_cmd;
     }

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface.cpp
@@ -408,7 +408,8 @@ void PacmodInterface::publishCommands()
   const double desired_steer_wheel = std::invoke([&]() -> double {
     double desired_steer_wheel{0.0};
     if (convert_steer_command_) {
-      (control_cmd_ptr_->lateral.steering_tire_angle - steering_offset_) * adaptive_gear_ratio;
+      desired_steer_wheel =
+        (control_cmd_ptr_->lateral.steering_tire_angle - steering_offset_) * adaptive_gear_ratio;
     } else {
       desired_steer_wheel = actuation_cmd_ptr_->actuation.steer_cmd;
     }


### PR DESCRIPTION
タイヤ角度 -> ハンドル角度への変換処理をraw_vehicle_cmd_converterに移動しようとしています。
https://github.com/autowarefoundation/autoware.universe/pull/8504

これは
- そもそもcontrol cmd(タイヤ角度)をpacmod_interafaceで変換しているが責任範囲に違和感がある
- vehicle interfaceごとに分かれた実装を共通化したい。
   - ハンドル角度で制御する車両は多い
   - ハンドル角度制御でsimulatorでのテストを行いたい
　   - https://github.com/autowarefoundation/autoware.universe/pull/8415 
   - 将来的に車種に依らない共通な補正機能を作っていきたい
  
 という背景です。

```
  /* parameter for steering conversion */
  enable_pub_steer_ = declare_parameter("enable_pub_steer", true);
  convert_steer_command_ = declare_parameter("convert_steer_command", true);
```
と、デフォルトではこれまで通りpacmod_interface側で変換を行うようにしています。(機能が安定したらfalseにしたいです)

またactuation_statusのsteer_statusとしては、タイヤ角度ではなくて、ハンドル角度を返すように変更しています。
これは raw_vehicle_cmd_converter でタイヤ角度に変換することを期待しているためです。現状このトピックは使われていないはずで、変更は動作に影響ないと思います。
```
actuation_status.status.steer_status = current_steer_wheel;
```

