### PR TITLE
feat(pacmod_interface): application of CIE

### DIFF
--- a/pacmod_interface/CMakeLists.txt
+++ b/pacmod_interface/CMakeLists.txt
@@ -13,6 +13,15 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+set(ENABLE_AGNOCAST_DEFAULT "$ENV{ENABLE_AGNOCAST}")
+if(ENABLE_AGNOCAST_DEFAULT STREQUAL "1")
+  set(ENABLE_AGNOCAST_DEFAULT "ON")
+else()
+  set(ENABLE_AGNOCAST_DEFAULT "OFF")
+endif()
+
+option(ENABLE_AGNOCAST "Enable Agnocast components" ${ENABLE_AGNOCAST_DEFAULT})
+
 ament_auto_add_executable(pacmod_additional_debug_publisher
   src/pacmod_additional_debug_publisher/pacmod_additional_debug_publisher_node.cpp
   src/pacmod_additional_debug_publisher/pacmod_additional_debug_publisher_main.cpp
@@ -43,9 +52,9 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-if("$ENV{ENABLE_AGNOCAST}")
+if(ENABLE_AGNOCAST)
   find_package(agnocastlib REQUIRED)
-  add_definitions(-DUSE_AGNOCAST_ENABLED)
+  target_compile_definitions(pacmod_interface PRIVATE USE_AGNOCAST_ENABLED)
   ament_target_dependencies(pacmod_interface agnocastlib)
 endif()
 

--- a/pacmod_interface/CMakeLists.txt
+++ b/pacmod_interface/CMakeLists.txt
@@ -43,6 +43,12 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+if("$ENV{ENABLE_AGNOCAST}")
+  find_package(agnocastlib REQUIRED)
+  add_definitions(-DUSE_AGNOCAST_ENABLED)
+  ament_target_dependencies(pacmod_interface agnocastlib)
+endif()
+
 ament_auto_package(
   INSTALL_TO_SHARE
   launch

--- a/pacmod_interface/package.xml
+++ b/pacmod_interface/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend condition="$ENABLE_AGNOCAST == 1">agnocastlib</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface_node.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface_node.cpp
@@ -17,11 +17,30 @@
 
 #include <memory>
 
+#ifdef USE_AGNOCAST_ENABLED
+#include "agnocast/agnocast_callback_isolated_executor.hpp"
+
+#include <cstdlib>
+#endif
+
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<PacmodInterface>();
+
+#ifdef USE_AGNOCAST_ENABLED
+  const char * enable_agnocast = std::getenv("ENABLE_AGNOCAST");
+  if (enable_agnocast && std::string(enable_agnocast) == "1") {
+    agnocast::CallbackIsolatedAgnocastExecutor executor;
+    executor.add_node(node);
+    executor.spin();
+  } else {
+    rclcpp::spin(node);
+  }
+#else
   rclcpp::spin(node);
+#endif
+
   rclcpp::shutdown();
   return 0;
 }

--- a/pacmod_interface/src/pacmod_interface/pacmod_interface_node.cpp
+++ b/pacmod_interface/src/pacmod_interface/pacmod_interface_node.cpp
@@ -21,6 +21,7 @@
 #include "agnocast/agnocast_callback_isolated_executor.hpp"
 
 #include <cstdlib>
+#include <string>
 #endif
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description
Use `CallbackIsolatedAgnocastExecutor` (CIE) for `pacmod_interface` node, as part of the effort to achieve middleware-transparent scheduling and optimize end-to-end response time across Autoware. By going through `autoware_agnocast_wrapper`, CIE activation is controlled by the `ENABLE_AGNOCAST` environment variable — when unset or `0`, the node runs with the standard ROS 2 executor as before; when set to `1`, it switches to `CallbackIsolatedAgnocastExecutor`.

### Changes
- **CMakeLists.txt**: Set `SingleThreadedExecutor` explicitly for `ROS_EXECUTOR` and changed to `CallbackIsolatedAgnocastExecutor` for `AGNOCAST_EXECUTOR` option.

## Related links

- Issue: https://github.com/autowarefoundation/autoware_core/issues/1056

- [AutowareDiscussion about adopting CIE](https://github.com/orgs/autowarefoundation/discussions/6813)
- [What is autoware_agnocast_wrapper?](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/README.md)

## How was this PR tested?

- The affected node is not present in Evaluator or Lsim environments, so verification was done by launching the node in isolation. (both ENABLE_AGNOCAST=0 and ENABLE_AGNOCAST=1).

## Notes for reviewers

**Please review the following aspects:**

- Verify that all relevant `CMakeLists.txt` for `pacmod_interface` node have been updated (no missed files).
- If the node meets **all** of the following conditions, please check for potential race conditions (see [Effects on system behavior](##effects-on-system-behavior) for the reason):
  1. The node was originally running on a `rclcpp::executors::SingleThreadedExecutor` or `rclcpp_components::component_container`
  2. The node has multiple callback groups (the default is one)
  3. Shared variables are accessed across callback groups without proper mutex protection

 **Note:** Nodes already running on `MultiThreadedExecutor` (or `component_container_mt`) are not affected, as their callbacks are already executed concurrently.

## Interface changes

None.

## Effects on system behavior

When `ENABLE_AGNOCAST=0` (default), there is no change in behavior at all — the node runs with the standard ROS 2 executor exactly as before.

When `ENABLE_AGNOCAST=1`, the executor switches to `CallbackIsolatedAgnocastExecutor` (CIE). Internally, CIE creates a dedicated `rclcpp::executors::SingleThreadedExecutor` for each callback group, so the fundamental scheduling behavior within each group remains almost identical. The key difference is that, for nodes originally using `rclcpp::executors::SingleThreadedExecutor`, callback groups now run in parallel across separate threads, similar to `MultiThreadedExecutor`.


<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->
